### PR TITLE
Fix encoding and path issues

### DIFF
--- a/lib/covered/files.rb
+++ b/lib/covered/files.rb
@@ -134,7 +134,7 @@ module Covered
 		attr :path
 		
 		def expand_path(path)
-			File.expand_path(super, @path)
+			File.expand_path(super, path)
 		end
 		
 		def relative_path(path)

--- a/lib/covered/persist.rb
+++ b/lib/covered/persist.rb
@@ -60,10 +60,10 @@ module Covered
 		end
 		
 		def load!(path = @path)
-			return unless File.exist?(@path)
+			return unless File.exist?(path)
 			
 			# Load existing coverage information and mark all files:
-			File.open(@path, "r") do |file|
+			File.open(path, "r") do |file|
 				file.flock(File::LOCK_SH)
 				
 				make_unpacker(file).each(&self.method(:apply))
@@ -72,7 +72,7 @@ module Covered
 		
 		def save!(path = @path)
 			# Dump all coverage:
-			File.open(@path, "w") do |file|
+			File.open(path, "wb") do |file|
 				file.flock(File::LOCK_EX)
 				
 				packer = make_packer(file)

--- a/spec/covered/persist_spec.rb
+++ b/spec/covered/persist_spec.rb
@@ -31,4 +31,36 @@ RSpec.describe Covered::Persist do
 	it "can serialize coverage" do
 		expect(record[:path]).to be == __FILE__
 	end
+	
+	context "with some data" do
+		let(:path) {"test.db"}
+		let(:writer) {described_class.new(Covered::Wrapper.new(Covered::Files.new), path)}
+		let(:reader) {described_class.new(Covered::Wrapper.new(Covered::Files.new), path)}
+		
+		before(:each) {writer.mark(__FILE__, 1, 2)}
+		after(:each) {File.unlink(path) if File.exist?(path)}
+		
+		it "can write to file" do
+			expect {writer.save!}.to_not raise_error
+			expect(File.size(path)).to_not be_zero
+		end
+		
+		it "can read from file" do
+			expect {writer.save!}.to_not raise_error
+			expect {reader.load!}.to_not raise_error
+			expect {|block| reader.output.each(&block)}.to yield_control.once
+			reader.output.each do |file|
+				expect(file[1]).to be == 2
+			end
+		end
+
+		context "with UTF-8 internal encoding" do
+			before(:each) {Encoding.default_internal = Encoding::UTF_8}
+			
+			it "should read and write without error" do
+				expect {writer.save!}.to_not raise_error
+				expect {reader.load!}.to_not raise_error
+			end
+		end
+	end
 end


### PR DESCRIPTION
This fixes a few typos where `path` and `@path` were used interchangably, and fixes an error serializing data to disk when UTF-8 was used as the internal encoding (e.g. in a project including ActiveRecord) and binary data was written to the coverage DB.

Added unit tests to check coverage saving and loading.