### PR TITLE
Fix require in minitest helper

### DIFF
--- a/lib/covered/minitest.rb
+++ b/lib/covered/minitest.rb
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-require_relative 'policy'
+require_relative 'config'
 
 require 'minitest'
 


### PR DESCRIPTION
Requiring `covered/minitest` per the docs results in a missing constant error.