### PR TITLE
Remove unused variable 'error' in rescue in `Persist#load!`

### DIFF
--- a/lib/covered/persist.rb
+++ b/lib/covered/persist.rb
@@ -70,7 +70,7 @@ module Covered
 					self.apply(record, **options)
 				end
 			end
-		rescue => error
+		rescue
 			raise LoadError, "Failed to load coverage from #{@path}, maybe old format or corrupt!"
 		end
 		


### PR DESCRIPTION
This removes an unused variable in `Persist` (the `error` variable in the rescue block of `#load!`) that results in a warning when `covered` is used with verbose warnings enable, ie `/workspaces/covered/lib/covered/persist.rb:73: warning: assigned but unused variable - error` 

Note sure if you would like to remove it or use the error message when re-raising, but this PR assumes the actual rescued error will be unused (hence variable removed)