### PR TITLE
Fix parsing input to covered:policy:statistics command

### DIFF
--- a/bake/covered/policy.rb
+++ b/bake/covered/policy.rb
@@ -37,12 +37,12 @@ end
 # @parameter minimum [Float] The minimum required coverage in order to pass.
 # @parameter input [Covered::Policy] The input policy to validate.
 def statistics(paths: nil, minimum: 1.0, input:)
-	policy ||= context.lookup("covered:policy:current").call(paths: paths)
+	input ||= context.lookup("covered:policy:current").call(paths: paths)
 	
 	# Calculate statistics:
 	statistics = Covered::Statistics.new
 	
-	policy.each do |coverage|
+	input.each do |coverage|
 		statistics << coverage
 	end
 	


### PR DESCRIPTION
If the `.covered.db` file is in a non-default place, the command could fail:
```
$ bake covered:policy:current paths=coverage/.covered.db covered:policy:statistics output format=json
 0.02s    error: Bake::Command [ec=0x67c] [pid=68850] [2023-07-21 22:26:31 +1200]
               |   ArgumentError: No coverage paths specified!
               |   → /Users/michael/.rvm/gems/ruby-3.2.2/gems/covered-0.24.2/bake/covered/policy.rb:23 in `current'
               |     /Users/michael/.rvm/gems/ruby-3.2.2/gems/bake-0.18.2/lib/bake/recipe.rb:127 in `call'
               |     /Users/michael/.rvm/gems/ruby-3.2.2/gems/covered-0.24.2/bake/covered/policy.rb:40 in `statistics'
```

Now it succeeds:
```
{
  "total": {
    "count": 5,
    "executable_count": 101,
    "executed_count": 100,
    "percentage": 99.01
  },
  "paths": { ... }
}
```