### PR TITLE
Minitest exit with non-zero status if coverage bellow minimum

### DIFF
--- a/lib/covered/minitest.rb
+++ b/lib/covered/minitest.rb
@@ -12,6 +12,9 @@ $covered = Covered::Config.load
 
 module Covered
 	module Minitest
+		MINIMUM_COVERAGE =
+			Float(ENV.fetch('MINIMUM_COVERAGE', 100.0))
+
 		def run(*)
 			$covered.start
 			
@@ -26,5 +29,11 @@ if $covered.record?
 	Minitest.after_run do
 		$covered.finish
 		$covered.call($stderr)
+
+		stats = Covered::Statistics.new
+
+		$covered.policy.each { stats << _1 }
+
+		stats.validate! Covered::Minitest::MINIMUM_COVERAGE / 100.0
 	end
 end

--- a/test/covered/minitest.rb
+++ b/test/covered/minitest.rb
@@ -11,11 +11,20 @@ describe "Covered::Minitest" do
 	
 	it "can run minitest test suite with coverage" do
 		input, output = IO.pipe
-		
-		system({"COVERAGE" => "PartialSummary"}, test_path, out: output, err: output)
+
+		env = {
+			"COVERAGE" => "PartialSummary",
+			"MINIMUM_COVERAGE" => "100.1"
+		}
+
+		system(env, test_path, out: output, err: output)
 		output.close
 
+		expect($?.exitstatus).not.to be(:zero?)
+
 		buffer = input.read
+
 		expect(buffer).to be =~ /(.*?) files checked; (.*?) lines executed; (.*?)% covered/
+		expect(buffer).to be =~ /is less than required minimum of 100.1/
 	end
 end


### PR DESCRIPTION
Fix #32

The minitest integration was exiting with success even if missing coverage.
Ideally it should exit with an error status, so integration processes can be halted and failures easily detected.

I was not able to find a proper way to specify a minimum coverage, so I used the ENV var MINIMUM_COVERAGE (default 100%).

## Types of Changes

- New feature.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).