### PR TITLE
Fix bake coverage policy configuration

### DIFF
--- a/bake/covered/policy.rb
+++ b/bake/covered/policy.rb
@@ -14,27 +14,7 @@ end
 # Defaults to the default coverage path if no paths are specified.
 # @parameter paths [Array(String)] The coverage database paths.
 def current(paths: nil, reports: Covered::Config.reports)
-	policy = Covered::Policy.new
-	
-	# Load the default path if no paths are specified:
-	paths ||= Dir.glob(Covered::Persist::DEFAULT_PATH, base: context.root)
-	
-	# If no paths are specified, raise an error:
-	if paths.empty?
-		raise ArgumentError, "No coverage paths specified!"
-	end
-	
-	# Load all coverage information:
-	paths.each do |path|
-		# It would be nice to have a better algorithm here than just ignoring mtime - perhaps using checksums?
-		Covered::Persist.new(policy.output, path).load!(ignore_mtime: true)
-	end
-	
-	if reports
-		policy.reports!(reports)
-	end
-	
-	return policy
+	return Covered::Config.load(root: context.root, reports: reports).policy_for(paths)
 end
 
 # Validate the coverage of multiple test runs.

--- a/bake/covered/validate.rb
+++ b/bake/covered/validate.rb
@@ -14,19 +14,19 @@ end
 # @parameter minimum [Float] The minimum required coverage in order to pass.
 # @parameter input [Covered::Policy] The input policy to validate.
 def validate(paths: nil, minimum: 1.0, input:)
-	policy ||= context.lookup("covered:policy:current").call(paths: paths)
+	input ||= context.lookup("covered:policy:current").call(paths: paths)
 	
 	# Calculate statistics:
 	statistics = Covered::Statistics.new
 	
-	policy.each do |coverage|
+	input.each do |coverage|
 		statistics << coverage
 	end
 	
 	# Print statistics:
 	statistics.print($stderr)
 	
-	policy.call(STDOUT)
+	input.call(STDOUT)
 	
 	# Validate statistics and raise an error if they are not met:
 	statistics.validate!(minimum)

--- a/lib/covered/config.rb
+++ b/lib/covered/config.rb
@@ -91,6 +91,27 @@ module Covered
 			policy.each(&block)
 		end
 		
+		# Build a configured policy using coverage data from persistent storage.
+		#
+		# @parameter paths [Array(String)] The coverage database paths.
+		# @parameter ignore_mtime [Boolean] Whether to ignore source file modification times.
+		# @returns [Covered::Policy] The configured policy with loaded coverage data.
+		def policy_for(paths = nil, ignore_mtime: true)
+			paths ||= Dir.glob(Persist::DEFAULT_PATH, base: @root)
+			paths = Array(paths)
+			
+			if paths.empty?
+				raise ArgumentError, "No coverage paths specified!"
+			end
+			
+			paths.each do |path|
+				# It would be nice to have a better algorithm here than just ignoring mtime - perhaps using checksums?
+				Persist.new(policy.output, path).load!(ignore_mtime: ignore_mtime)
+			end
+			
+			return policy
+		end
+		
 		# Which paths to ignore when computing coverage for a given project.
 		# @returns [Array(String)] An array of relative paths to ignore.
 		def ignore_paths

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Ensure bake coverage validation loads persisted coverage using project configuration.
+
 ## v0.28.0
 
   - List files that have 100% coverage in `PartialSummary` output.

--- a/test/covered/persist.rb
+++ b/test/covered/persist.rb
@@ -4,8 +4,11 @@
 # Copyright, 2019-2025, by Samuel Williams.
 
 require "covered/coverage"
+require "covered/config"
 require "covered/persist"
+require "sus/fixtures/temporary_directory_context"
 require "wrapper_examples"
+require "fileutils"
 
 describe Covered::Persist do
 	it_behaves_like WrapperExamples
@@ -17,5 +20,40 @@ describe Covered::Persist do
 	
 	it "can serialize coverage" do
 		expect(record[:path]).to be == __FILE__
+	end
+end
+
+describe Covered::Config do
+	include Sus::Fixtures::TemporaryDirectoryContext
+	
+	it "loads persisted coverage using the configured policy" do
+		FileUtils.mkdir_p(File.join(root, "config"))
+		FileUtils.mkdir_p(File.join(root, "examples"))
+		FileUtils.mkdir_p(File.join(root, "lib"))
+		
+		File.write(File.join(root, "config", "covered.rb"), <<~RUBY)
+			def ignore_paths
+				super + ["examples/"]
+			end
+		RUBY
+		
+		example_path = File.join(root, "examples", "example.rb")
+		lib_path = File.join(root, "lib", "example.rb")
+		
+		File.write(example_path, "puts :example\n")
+		File.write(lib_path, "puts :lib\n")
+		
+		output = Covered::Files.new
+		output.add(Covered::Coverage.new(Covered::Source.new(example_path), [1]))
+		output.add(Covered::Coverage.new(Covered::Source.new(lib_path), [1]))
+		
+		database_path = File.join(root, Covered::Persist::DEFAULT_PATH)
+		Covered::Persist.new(output, database_path).save!
+		
+		config = subject.load(root: root, reports: false)
+		policy = config.policy_for(database_path)
+		
+		expect(policy.to_h).to have_keys(lib_path)
+		expect(policy.to_h).not.to have_keys(example_path)
 	end
 end


### PR DESCRIPTION
## Summary
- add Covered::Config#policy_for to load persisted coverage through project configuration
- update covered:policy:current to honor config/covered.rb when reading .covered.db
- fix covered:validate to use chained input when provided
- add a Sus temporary directory fixture regression test for configured path exclusion

## Testing
- ruby -c lib/covered/config.rb
- ruby -c bake/covered/policy.rb
- ruby -c bake/covered/validate.rb
- ruby -c test/covered/persist.rb
- /nix/store/jh918yiwd5cs4pjg005ac32m2q7ckw3l-ruby-4.0.5/bin/ruby /Users/samuel/.gem/ruby/4.0.0/bin/sus test/covered/persist.rb