### PR TITLE
Ignore nil coverage reports

### DIFF
--- a/lib/covered/policy.rb
+++ b/lib/covered/policy.rb
@@ -133,7 +133,9 @@ module Covered
 		# Configure reports from names, booleans, arrays or report objects.
 		# @parameter reports [String | Boolean | Array | Object | Nil] The reports to configure.
 		def reports!(reports)
-			if reports.is_a?(String)
+			if reports.nil?
+				return
+			elsif reports.is_a?(String)
 				names = reports.split(",")
 				
 				names.each do |name|

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Ignore nil coverage reports so validation can run without `COVERAGE` configured.
+
 ## v0.28.2
 
   - Ensure bake coverage validation loads persisted coverage using project configuration.

--- a/test/covered/policy.rb
+++ b/test/covered/policy.rb
@@ -4,6 +4,7 @@
 # Copyright, 2018-2025, by Samuel Williams.
 
 require "covered/policy"
+require "covered/brief_summary"
 
 describe Covered::Policy do
 	let(:pattern) {"**/*.rb"}
@@ -55,6 +56,13 @@ describe Covered::Policy do
 		policy.reports!("BriefSummary,PartialSummary")
 		
 		expect(policy.reports.count).to be == 2
+	end
+	
+	it "ignores nil reports" do
+		policy.reports!(nil)
+		
+		expect(policy.reports).to be(:empty?)
+		expect{policy.call(StringIO.new)}.not.to raise_exception
 	end
 	
 	it "can #call" do


### PR DESCRIPTION
## Summary
- treat nil reports as no configured reports in Covered::Policy#reports!
- add a regression test that policy.call does not fail after reports!(nil)
- add an unreleased note for validation without COVERAGE

## Testing
- /nix/store/jh918yiwd5cs4pjg005ac32m2q7ckw3l-ruby-4.0.5/bin/ruby /Users/samuel/.gem/ruby/4.0.0/bin/sus test/covered/policy.rb
- /nix/store/jh918yiwd5cs4pjg005ac32m2q7ckw3l-ruby-4.0.5/bin/ruby -c lib/covered/policy.rb
- /nix/store/jh918yiwd5cs4pjg005ac32m2q7ckw3l-ruby-4.0.5/bin/ruby -c test/covered/policy.rb
- RUBYLIB=/Users/samuel/Developer/socketry/covered/lib:/Users/samuel/Developer/socketry/covered COVERAGE= bundle exec bake covered:validate --minimum 0.85