### PR TITLE
Fix coverage validation persistence

### DIFF
--- a/bake/covered/policy.rb
+++ b/bake/covered/policy.rb
@@ -14,7 +14,7 @@ end
 # Defaults to the default coverage path if no paths are specified.
 # @parameter paths [Array(String)] The coverage database paths.
 def current(paths: nil, reports: Covered::Config.reports)
-	return Covered::Config.load(root: context.root, reports: reports).policy_for(paths)
+	return Covered::Config.load(root: context.root, reports: reports, persist: false).policy_for(paths)
 end
 
 # Validate the coverage of multiple test runs.

--- a/lib/covered/config.rb
+++ b/lib/covered/config.rb
@@ -36,8 +36,9 @@ module Covered
 		# Load the project coverage configuration for the given root.
 		# @parameter root [String] The project root.
 		# @parameter reports [String | Boolean | Array | Object | Nil] The report configuration.
+		# @parameter persist [Boolean] Whether the configured policy should persist coverage to the default database.
 		# @returns [Covered::Config] The loaded configuration instance.
-		def self.load(root: self.root, reports: self.reports)
+		def self.load(root: self.root, reports: self.reports, persist: true)
 			derived = Class.new(self)
 			
 			if path = self.path(root)
@@ -46,16 +47,18 @@ module Covered
 				derived.prepend(config)
 			end
 			
-			return derived.new(root, reports)
+			return derived.new(root, reports, persist)
 		end
 		
 		# Initialize the configuration for a project root and reports.
 		# @parameter root [String] The project root.
 		# @parameter reports [String | Boolean | Array | Object | Nil] The report configuration.
-		def initialize(root, reports)
+		# @parameter persist [Boolean] Whether the configured policy should persist coverage to the default database.
+		def initialize(root, reports, persist = true)
 			@root = root
 			@reports = reports
 			@policy = nil
+			@persist = persist
 			
 			@environment = nil
 		end
@@ -169,7 +172,7 @@ module Covered
 				policy.include(pattern)
 			end
 			
-			policy.persist!
+			policy.persist! if @persist
 			
 			policy.reports!(@reports)
 		end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Ensure coverage validation loads explicit coverage databases without reloading the default persisted database.
+
 ## v0.28.3
 
   - Ignore nil coverage reports so validation can run without `COVERAGE` configured.

--- a/test/covered/persist.rb
+++ b/test/covered/persist.rb
@@ -56,4 +56,23 @@ describe Covered::Config do
 		expect(policy.to_h).to have_keys(lib_path)
 		expect(policy.to_h).not.to have_keys(example_path)
 	end
+	
+	it "loads persisted coverage from an explicit path without reloading the default database" do
+		FileUtils.mkdir_p(File.join(root, "coverage"))
+		FileUtils.mkdir_p(File.join(root, "lib"))
+		
+		lib_path = File.join(root, "lib", "example.rb")
+		File.write(lib_path, "puts :lib\n")
+		
+		output = Covered::Files.new
+		output.add(Covered::Coverage.new(Covered::Source.new(lib_path), [1]))
+		
+		database_path = File.join(root, "coverage", "artifact.covered.db")
+		Covered::Persist.new(output, database_path).save!
+		
+		config = subject.load(root: root, reports: false, persist: false)
+		policy = config.policy_for(database_path)
+		
+		expect(policy.to_h.fetch(lib_path).executable_count).to be == 1
+	end
 end


### PR DESCRIPTION
## Summary

- add an explicit non-persistent coverage configuration mode
- use non-persistent policy loading for coverage validation tasks
- add a regression test for validating explicit coverage database paths
- add unreleased release note

## Testing

- rubocop -A
- bundle exec sus test/covered/persist.rb