### PR TITLE
Avoid duplicate validation summaries

### DIFF
--- a/bake/covered/validate.rb
+++ b/bake/covered/validate.rb
@@ -23,8 +23,9 @@ def validate(paths: nil, minimum: 1.0, input:)
 		statistics << coverage
 	end
 	
-	# Print statistics:
-	statistics.print($stderr)
+	if input.reports.empty?
+		statistics.print($stderr)
+	end
 	
 	input.call(STDOUT)
 	

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Avoid duplicate coverage summaries when validation uses a configured coverage report.
+
 ## v0.28.4
 
   - Ensure coverage validation loads explicit coverage databases without reloading the default persisted database.

--- a/test/covered/validate.rb
+++ b/test/covered/validate.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "bake/context"
+require "covered/coverage"
+require "covered/policy"
+
+describe "covered:validate" do
+	let(:context) {Bake::Context.load(File.expand_path("../..", __dir__))}
+	let(:recipe) {context.lookup("covered:validate")}
+	let(:validate) {recipe.instance}
+	let(:file) {__FILE__}
+	let(:coverage) {Covered::Coverage.new(Covered::Source.new(file), [1])}
+	let(:policy) do
+		Covered::Policy.new.tap do |policy|
+			policy.add(coverage)
+		end
+	end
+	
+	it "prints statistics when there are no configured reports" do
+		output = []
+		
+		mock($stderr) do |mock|
+			mock.replace(:puts) do |line|
+				output << line
+			end
+		end
+		
+		validate.validate(input: policy)
+		
+		expect(output.first).to be == "1 files checked; 1/1 lines executed; 100.0% covered."
+	end
+	
+	it "delegates output to configured reports" do
+		lines = []
+		
+		report = proc do |input, output|
+			output.puts "custom report: #{input.to_h.count}"
+		end
+		
+		policy.reports << report
+		
+		mock(STDOUT) do |mock|
+			mock.replace(:puts) do |line|
+				lines << line
+			end
+		end
+		
+		validate.validate(input: policy)
+		
+		expect(lines).to be == ["custom report: 1"]
+	end
+end


### PR DESCRIPTION
## Summary

- only print the validate task fallback summary when no reports are configured
- delegate validation output to configured reports when present
- add regression coverage for both validation output paths
- add an Unreleased note

## Testing

- bundle exec sus test/covered/validate.rb
- bundle exec sus
- bundle exec rubocop -A
- COVERAGE=PartialSummary bundle exec bake covered:validate --paths .covered.db \;