### PR TITLE
Quiet validation without reports

### DIFF
--- a/bake/covered/validate.rb
+++ b/bake/covered/validate.rb
@@ -23,10 +23,6 @@ def validate(paths: nil, minimum: 1.0, input:)
 		statistics << coverage
 	end
 	
-	if input.reports.empty?
-		statistics.print($stderr)
-	end
-	
 	input.call(STDOUT)
 	
 	# Validate statistics and raise an error if they are not met:

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+  - Make coverage validation quiet when no reports are configured.
   - Avoid duplicate coverage summaries when validation uses a configured coverage report.
 
 ## v0.28.4

--- a/test/covered/validate.rb
+++ b/test/covered/validate.rb
@@ -19,18 +19,26 @@ describe "covered:validate" do
 		end
 	end
 	
-	it "prints statistics when there are no configured reports" do
+	it "does not print statistics when there are no configured reports" do
 		output = []
+		errors = []
 		
-		mock($stderr) do |mock|
+		mock(STDOUT) do |mock|
 			mock.replace(:puts) do |line|
 				output << line
 			end
 		end
 		
+		mock($stderr) do |mock|
+			mock.replace(:puts) do |line|
+				errors << line
+			end
+		end
+		
 		validate.validate(input: policy)
 		
-		expect(output.first).to be == "1 files checked; 1/1 lines executed; 100.0% covered."
+		expect(output).to be(:empty?)
+		expect(errors).to be(:empty?)
 	end
 	
 	it "delegates output to configured reports" do


### PR DESCRIPTION
## Summary

- remove the fallback summary from covered:validate when no reports are configured
- keep configured reports as the only validation output path
- update validation tests for quiet no-report behavior
- add an Unreleased note

## Testing

- bundle exec sus test/covered/validate.rb
- bundle exec sus
- bundle exec rubocop -A
- bundle exec bake covered:validate --paths .covered.db \;