### PR TITLE
Improve adapter integration coverage

### DIFF
--- a/fixtures/autostart/report.rb
+++ b/fixtures/autostart/report.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+puts "autostart fixture"

--- a/fixtures/sus/dummy.rb
+++ b/fixtures/sus/dummy.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+describe "Hello World Sus Test" do
+	it "can hello world" do
+		expect("Hello World").to be == "Hello World"
+	end
+end

--- a/test/covered/autostart.rb
+++ b/test/covered/autostart.rb
@@ -3,10 +3,24 @@
 # Released under the MIT License.
 # Copyright, 2026, by Samuel Williams.
 
+require "covered"
 require "covered/config"
 
 describe "Coverage::Autostart" do
+	let(:script_path) {File.expand_path("../../fixtures/autostart/report.rb", __dir__)}
+	
 	it "reports at exit when reports are enabled" do
+		input, output = IO.pipe
+		
+		system({"COVERAGE" => "PartialSummary"}, "ruby", "-rcovered/autostart", script_path, out: output, err: output)
+		output.close
+		
+		buffer = input.read
+		expect(buffer).to be(:include?, "autostart fixture")
+		expect(buffer).to be =~ /(.*?) files checked; (.*?) lines executed; (.*?)% covered/
+	end
+	
+	it "starts coverage and reports at exit" do
 		events = []
 		exit_hook = nil
 		

--- a/test/covered/minitest.rb
+++ b/test/covered/minitest.rb
@@ -18,6 +18,7 @@ describe "Covered::Minitest" do
 		
 		buffer = input.read
 		expect(buffer).to be =~ /(.*?) files checked; (.*?) lines executed; (.*?)% covered/
+		expect(buffer).to be(:include?, "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips")
 	end
 	
 	it "starts coverage before running minitest" do

--- a/test/covered/rspec.rb
+++ b/test/covered/rspec.rb
@@ -19,6 +19,7 @@ describe "Covered::RSpec" do
 		
 		buffer = input.read
 		expect(buffer).to be =~ /(.*?) files checked; (.*?) lines executed; (.*?)% covered/
+		expect(buffer).to be(:include?, "1 example, 0 failures")
 	end
 	
 	it "starts coverage before loading spec files" do

--- a/test/covered/sus.rb
+++ b/test/covered/sus.rb
@@ -3,9 +3,12 @@
 # Released under the MIT License.
 # Copyright, 2026, by Samuel Williams.
 
+require "covered"
 require "covered/sus"
 
 describe Covered::Sus do
+	let(:test_path) {File.expand_path("../../fixtures/sus/dummy.rb", __dir__)}
+	
 	let(:coverage) do
 		Class.new do
 			attr :events
@@ -66,6 +69,17 @@ describe Covered::Sus do
 				super
 			end
 		end
+	end
+	
+	it "can run sus test suite with coverage" do
+		input, output = IO.pipe
+		
+		system({"COVERAGE" => "PartialSummary"}, "sus", test_path, out: output, err: output)
+		output.close
+		
+		buffer = input.read
+		expect(buffer).to be =~ /(.*?) files checked; (.*?) lines executed; (.*?)% covered/
+		expect(buffer).to be(:include?, "1 passed out of 1 total")
 	end
 	
 	it "starts and finishes configured coverage" do


### PR DESCRIPTION
This leans the framework adapter tests toward the way Covered is used in practice: each adapter is exercised through a real subprocess entrypoint, while the existing focused parent-process probes preserve self-coverage for lines that run before coverage starts or after it finishes.

- Assert RSpec and Minitest framework output in the existing coverage subprocess tests.
- Add a Sus subprocess fixture that runs through Covered::Sus with coverage enabled.
- Add an autostart subprocess fixture that exercises `ruby -rcovered/autostart` and verifies report output.
- Keep Covered self-coverage at 100%.