### PR TITLE
Make ruby-coverage optional until capture starts

### DIFF
--- a/covered.gemspec
+++ b/covered.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "console", "~> 1.0"
 	spec.add_dependency "msgpack", "~> 1.0"
-	spec.add_dependency "ruby-coverage", "~> 0.1"
+	
+	spec.add_development_dependency "ruby-coverage", "~> 0.1"
 end

--- a/lib/covered/capture.rb
+++ b/lib/covered/capture.rb
@@ -5,7 +5,11 @@
 
 require_relative "wrapper"
 
-require "ruby/coverage"
+begin
+	require "ruby/coverage"
+rescue LoadError => error
+	raise error.exception("Covered::Capture requires the `ruby-coverage` gem. Add `gem \"ruby-coverage\", \"~> 0.1\"` to your bundle to record coverage.")
+end
 
 module Covered
 	# Captures Ruby coverage data and forwards it to another coverage output.

--- a/lib/covered/policy.rb
+++ b/lib/covered/policy.rb
@@ -5,7 +5,6 @@
 
 require_relative "summary"
 require_relative "files"
-require_relative "capture"
 require_relative "persist"
 require_relative "forks"
 
@@ -67,6 +66,8 @@ module Covered
 		# The runtime capture pipeline for this policy.
 		# @returns [Covered::Forks] The memoized capture pipeline.
 		def capture
+			require_relative "capture"
+			
 			@capture ||= Forks.new(
 				Capture.new(@output)
 			)

--- a/test/covered/sus.rb
+++ b/test/covered/sus.rb
@@ -5,6 +5,11 @@
 
 require "covered/sus"
 
+require "covered/config"
+
+require "fileutils"
+require "tmpdir"
+
 describe Covered::Sus do
 	let(:coverage) do
 		Class.new do
@@ -125,5 +130,18 @@ describe Covered::Sus do
 		runner.after_tests(:assertions)
 		
 		expect(runner.covered).to be_nil
+	end
+	
+	it "does not require ruby-coverage when coverage is not requested" do
+		Dir.mktmpdir do |root|
+			FileUtils.mkdir_p(File.join(root, "ruby"))
+			File.write(File.join(root, "ruby", "coverage.rb"), "abort 'ruby-coverage was required'")
+			
+			code = <<~RUBY
+			require "covered/sus"
+			RUBY
+			
+			expect(system({"COVERAGE" => nil, "RUBYOPT" => nil}, Gem.ruby, "-Ilib", "-I#{root}", "-e", code)).to be == true
+		end
 	end
 end


### PR DESCRIPTION
# TL;DR

Make `ruby-coverage` optional until coverage capture is actually started, so consumers can load `covered/sus` without installing or building the native `ruby-coverage` extension.

# Context

This came up while fixing `socketry/io-event` CI. `io-event` loads `covered/sus` from its Sus configuration, but normal test jobs do not set `COVERAGE`. Even though `Covered::Sus` already avoids loading `Covered::Config` unless `COVERAGE` is set, `covered` still declared `ruby-coverage` as a runtime dependency and `Covered::Policy` eagerly required `covered/capture`, which required `ruby/coverage`.

That means applications can pay the native dependency install/build cost even when they are not recording coverage. On platforms where `ruby-coverage` is not usable, that fails before tests get to run.

# Changes

- Move `ruby-coverage` from a runtime dependency to a development dependency.
- Defer `covered/capture` loading until `Covered::Policy#capture` is used.
- Keep an explicit `ruby/coverage` require in `Covered::Capture`, but convert missing dependency failures into a targeted `LoadError` explaining what gem to add when recording coverage.
- Add a `Covered::Sus` regression test that runs in a child Ruby process with a trap `ruby/coverage.rb` earlier in `$LOAD_PATH`; requiring `covered/sus` with `COVERAGE` unset must not trigger that trap.

# Tophatting

```bash
PATH=/Users/samuel/.local/state/tec/profiles/base/current/global/bin:$PATH /Users/samuel/.local/state/tec/profiles/base/current/global/bin/bundle exec bake test
# 71 passed out of 71 total

/Users/samuel/.local/state/tec/profiles/base/current/global/bin/bundle exec sus test/covered/sus.rb
# 4 passed out of 4 total
```
